### PR TITLE
[FIX] Ignore empty results from morfix

### DIFF
--- a/dics.js
+++ b/dics.js
@@ -368,6 +368,11 @@ function morfix_process_result(search_result) {
                 })
 
             });
+
+            if (new_result[Words].length === 0) {
+                new_result.error = ERROR_CODE_NO_RESULTS
+            }
+            
             break;
 
         default:


### PR DESCRIPTION
Morfix has started to return a "Match" without any results, so we need to ignore such case